### PR TITLE
Proposal: persistent "mydata" folder for custom user notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/.DS_Store
 .ipynb_checkpoints
 **/.ipynb_checkpoints
+mydata/*.ipynb

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ This isn't designed for production use, this is for local or trusted use only.
 There are a few example notebooks included in the image, their usefulness
 might vary according to your experience level.
 
+## Creating Your Own Notebooks
+
+There is a "mydata" folder that you can create your own notebooks in. It is tied to your local file system, and thus will persist over time.
+
 ## Inspiration
 
 - [MBSE4U.com](https://mbse4u.com/2020/12/21/sysml-v2-release-whats-inside/) is where I found the meta commands.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     ports:
       - "8888:8888"
     restart: always
+    volumes:
+      - "./mydata:/home/sysml/SysML-v2-Release-${RELEASE}/mydata"
 
 networks:
   default:


### PR DESCRIPTION
I find this repo hugely helpful to explore SysML v2 - one thing I ran into is that there isn't a persistent data folder tying the local file system to the running docker (jupyter) container. I added one (arbitrarily called "mydata") to allow this.

- [x] Add `.gitkeep` to `mydata` folder and add empty folder to source control
- [x] Add `mydata/*.ipynb` to `.gitignore` to avoid accidentally commited notebooks.
- [x] Map local ./mydata folder to Jupyter Lab container in `docker-compose.yml`
- [x] Update `README.md` to mention mydata folder

I much appreciate the sysmlv2-jupyter-docker repo, thanks so much!