### PR TITLE
Fixed texlive repo issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get --quiet --yes update && apt-get install -yqq \
   wget                        \
   inkscape                    \
   texlive-fonts-recommended   \
-  texlive-generic-recommended \
+  texlive-base \
   texlive-xetex
 
 ##

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -10,7 +10,7 @@ RUN apt-get --quiet --yes update && apt-get install -yqq \
   wget                        \
   inkscape                    \
   texlive-fonts-recommended   \
-  texlive-generic-recommended \
+  texlive-base \
   texlive-xetex
 
 ##

--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -14,7 +14,7 @@ RUN apt-get --quiet --yes update && apt-get install -yqq \
   wget                        \
   inkscape                    \
   texlive-fonts-recommended   \
-  texlive-generic-recommended \
+  texlive-base \
   texlive-xetex
 
 ##


### PR DESCRIPTION
Looks like `texlive-generic-recommended` is no longer a thing, apparently we need to use `texlive-base` now.