### PR TITLE
Added uninstall of the jupyter lab terminal feature for security reasons

### DIFF
--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -66,6 +66,9 @@ WORKDIR ${HOME}/SysML-v2-Release-${RELEASE}/install/jupyter
 ENV PATH="${HOME}/conda/bin:${HOME}/conda/condabin:/usr/local/openjdk-17/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 RUN ./install.sh
 
+## Uninstall the terminal feature for security reasons
+RUN pip uninstall -y terminado
+
 WORKDIR ${HOME}/SysML-v2-Release-${RELEASE}/
 
 ## Move any files in the top level directory to the doc directory


### PR DESCRIPTION
It seems that the terminal function was used to abuse the server for mining. Maybe other ways have been taken, but with this fix at least one door is closed.