### PR TITLE
Added uninstall of python kernel

### DIFF
--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -68,6 +68,7 @@ RUN ./install.sh
 
 ## Uninstall the terminal feature for security reasons
 RUN pip uninstall -y terminado
+RUN jupyter kernelspec uninstall python3 -y
 
 WORKDIR ${HOME}/SysML-v2-Release-${RELEASE}/
 

--- a/scripts/hub.sh
+++ b/scripts/hub.sh
@@ -17,4 +17,4 @@ echo '{"data":{"layout-restorer:data":{"main":{"dock":{"type":"tab-area","curren
 jupyter lab workspaces import /home/sysml/.jupyter/lab.json
 
 ## Start up Jupyter lab.
-jupyter lab --ip 0.0.0.0 --port 8888 --no-browser
+jupyter lab --ip 0.0.0.0 --port 8888 --no-browser --KernelSpecManager.ensure_native_kernel=False


### PR DESCRIPTION
The python kernel is used by hackers to run mining scripts on the server.

It would be great to also change a kernel spec setting, but I don't know how to update the config file in the dockerfile. The setting can also be set when starting the jupyter lab:

jupyter lab --KernelSpecManager.ensure_native_kernel=False