### PR TITLE
Introduced more buildparameters

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -6,7 +6,7 @@ FROM openjdk:11-slim
 ## designed to be run with docker compose.
 ##
 
-RUN apt-get --quiet --yes update && apt-get install -yqq wget
+RUN apt-get --quiet --yes update && apt-get install -yqq wget xmlstarlet
 
 ##
 ## Use a non-root user for installation
@@ -58,11 +58,14 @@ RUN sed s/key=.whatever./key=\"longersecretnowarnings\"/ -i conf/application.con
 ## need to allow the jupyter server access to the API server
 RUN echo "\n\nplay.filters.hosts {\n   allowed = [\"sysmlapiserver:9000\", \"localhost:9000\"]\n}\n" >> conf/application.conf
 
-## point the image to the postgres that is setup via docker compose
-RUN sed s/localhost:5432/postgresdbserver:5432/ -i conf/META-INF/persistence.xml
-
-## don't recreate the database if it already exists.
-RUN sed s/value=.create-drop./value=\"update\"/ -i conf/META-INF/persistence.xml
+## set the database connection information
+ARG DB_SERVER_URL="jdbc:postgresql://postgresdbserver:5432/sysml2"
+ARG DB_USER="postgres"
+ARG DB_PASSWORD="mysecretpassword"
+RUN xmlstarlet ed --inplace -u '_:persistence/_:persistence-unit/_:properties/_:property[@name="javax.persistence.jdbc.url"]/@value' -v ${DB_SERVER_URL} conf/META-INF/persistence.xml \
+    && xmlstarlet ed --inplace -u '_:persistence/_:persistence-unit/_:properties/_:property[@name="javax.persistence.jdbc.user"]/@value' -v ${DB_USER} conf/META-INF/persistence.xml \
+    && xmlstarlet ed --inplace -u '_:persistence/_:persistence-unit/_:properties/_:property[@name="javax.persistence.jdbc.password"]/@value' -v ${DB_PASSWORD} conf/META-INF/persistence.xml \
+    && xmlstarlet ed --inplace -u '_:persistence/_:persistence-unit/_:properties/_:property[@name="hibernate.hbm2ddl.auto"]/@value' -v "update" conf/META-INF/persistence.xml
 
 EXPOSE 9000
 ENTRYPOINT ${HOME}/sbt/bin/sbt run

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -56,8 +56,8 @@ RUN ${HOME}/sbt/bin/sbt compile
 RUN sed s/key=.whatever./key=\"longersecretnowarnings\"/ -i conf/application.conf
 
 ## need to allow the jupyter server access to the API server
-ARG API_SERVER_NAME="sysmlapiserver:9000"
-RUN echo "\n\nplay.filters.hosts {\n   allowed = [\"${API_SERVER_NAME}\", \"localhost:9000\"]\n}\n" >> conf/application.conf
+ARG SYSML_API_SERVER="sysmlapiserver:9000"
+RUN echo "\n\nplay.filters.hosts {\n   allowed = [\"${SYSML_API_SERVER}\", \"localhost:9000\"]\n}\n" >> conf/application.conf
 
 ## set the database connection information
 ARG DB_SERVER_URL="jdbc:postgresql://postgresdbserver:5432/sysml2"

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -56,7 +56,8 @@ RUN ${HOME}/sbt/bin/sbt compile
 RUN sed s/key=.whatever./key=\"longersecretnowarnings\"/ -i conf/application.conf
 
 ## need to allow the jupyter server access to the API server
-RUN echo "\n\nplay.filters.hosts {\n   allowed = [\"sysmlapiserver:9000\", \"localhost:9000\"]\n}\n" >> conf/application.conf
+ARG API_SERVER_NAME="sysmlapiserver:9000"
+RUN echo "\n\nplay.filters.hosts {\n   allowed = [\"${API_SERVER_NAME}\", \"localhost:9000\"]\n}\n" >> conf/application.conf
 
 ## set the database connection information
 ARG DB_SERVER_URL="jdbc:postgresql://postgresdbserver:5432/sysml2"

--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -15,7 +15,8 @@ RUN apt-get --quiet --yes update && apt-get install -yqq \
   inkscape                    \
   texlive-fonts-recommended   \
   texlive-base                \
-  texlive-xetex
+  texlive-xetex               \
+  jq
 
 ##
 ## Non-root user is a requirement of Binder:
@@ -81,7 +82,9 @@ RUN pip install euporie
 RUN ./install.sh
 
 ## Point the publish command to the local API server.
-RUN sed s/sysml2.intercax.com:9000/sysmlapiserver:9000/ -i ${HOME}/conda/share/jupyter/kernels/sysml/kernel.json
+# RUN sed s/sysml2.intercax.com:9000/sysmlapiserver:9000/ -i ${HOME}/conda/share/jupyter/kernels/sysml/kernel.json
+ARG SYSML_API_SERVER=http://sysmlapiserver:9000
+RUN jq --arg api_server "${SYSML_API_SERVER}" '.env.ISYSML_API_BASE_PATH = $api_server' ${HOME}/conda/share/jupyter/kernels/sysml/kernel.json > .tmp.kernel.json && mv .tmp.kernel.json ${HOME}/conda/share/jupyter/kernels/sysml/kernel.json
 
 ## Uninstall the terminal feature for security reasons
 RUN pip uninstall -y terminado

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,28 @@
 # SysMLv2 Release to use. First is release version of the API server, the second is
 # the release version of the SysMLv2
 release = 2024-02
-sysml_release= 2024-02
+sysml_release= 2024-05
+
+
+# Jupyter - API server URL
+SYSML_API_SERVER=http://sysmlapiserver:9000
+
+# API server
+DB_SERVER_URL = 'jdbc:postgresql://postgresdbserver:5432/sysml2'
+DB_USER = 'postgres'
+DB_PASSWORD = 'mysecretpassword'
+
 
 ##
 ## Local setup
 ##
 .PHONY: build-api
 build-api: ## build the API server docker image
-	docker build -t sysml.api:$(release) -f Dockerfile.api --build-arg RELEASE=$(release) .
+	docker build -t sysml.api:$(release) -f Dockerfile.api --build-arg RELEASE=$(release) --build-arg DB_SERVER_URL=$(DB_SERVER_URL) --build-arg DB_USER=$(DB_USER) --build-arg DB_PASSWORD=$(DB_PASSWORD) .
 
 .PHONY: build-jupyter
 build-jupyter: ## build the API+Jupyter Jupyter docker image
-	docker build -t sysml.jupyter:$(sysml_release) -f Dockerfile.jupyter --build-arg RELEASE=$(sysml_release) .
+	docker build -t sysml.jupyter:$(sysml_release) -f Dockerfile.jupyter --build-arg RELEASE=$(sysml_release) --build-arg SYSML_API_SERVER=$(SYSML_API_SERVER) .
 
 .PHONY: create-periphery
 create-periphery: ## Create network and volume for docker compose

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ sysml_release= 2024-05
 
 
 # Jupyter - API server URL
-SYSML_API_SERVER=http://sysmlapiserver:9000
+SYSML_API_SERVER=sysmlapiserver:9000
 
 # API server
 DB_SERVER_URL = 'jdbc:postgresql://postgresdbserver:5432/sysml2'

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,11 @@ run-hub: build-hub ## Run dockerhub image
 build: build-api build-hub build-mybinder build-jupyter ## build all images
 	echo done
 
+.PHONY: build-latest
+build-latest: build-api build-jupyter
+	docker tag sysml.api:$(release) sysml.api:latest
+	docker tag sysml.jupyter:$(sysml_release) sysml.jupyter:latest
+
 .PHONY: get-notebooks
 get-notebooks: ## retrieve all notebooks in a standalone running container
 	docker exec -i $$(docker ps | grep sysml.jupyter | awk '// { print $$1 }') /bin/bash -c "tar czf - notebooks" | tar xzf -

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ The Makefile also does the following builds for local usage:
 
 2. `make build-hub` will build the docker hub image. Running this image can be done with `make run-hub`.
 
+3. `make build-api DB_SERVER_URL=<server url> DB_USER=<username in your db> DB_PASSWORD=<your password>` builds the api server for the defined database server.
+
+4. `make build-jupyter SYSML_API_SERVER=<your API server>` builds the jupyter container image for your api server instance.
+
+5. `make build-latest` builds the api server and jupyter server as defined above and labels it as latest. The aformentioned build arguments can be used, too.
+
 These also work for each release that is supported by this repo.
 
 ### Checking out other releases


### PR DESCRIPTION
Extended the parametrization of the builds for api and jupyter. Implemented the config file updates more robust. Documented. Now it can be more easily built for other environments
e.g.
```bash
make build-api DB_SERVER_URL=jdbc:postgresql://anotherpostgres_server_instance:5432/my_project_database DB_USER=sysml2_master_user DB_PASSWORD=dkfjhsdlkjfjhsldjfldskjfsdjflsdjflksjdlkfds
```