### PR TITLE
Add prefix "http://" to the SYSML_API_SERVER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ sysml_release= 2024-05
 
 
 # Jupyter - API server URL
-SYSML_API_SERVER=sysmlapiserver:9000
+SYSML_API_SERVER=http://sysmlapiserver:9000
 
 # API server
 DB_SERVER_URL = 'jdbc:postgresql://postgresdbserver:5432/sysml2'


### PR DESCRIPTION
**Summary**

The [`KernelMagic.ipynb`](https://github.com/gorenje/sysmlv2-jupyter-docker/blob/main/notebooks/gorenje/KernelMagic.ipynb) notebook has the following output from the `%publish` command

```
API base path: http://sysmlapiserver:9000
Processing
Posting Commit (39 elements)...
```

The "http://" is missing from the Makefile SYSML_API_SERVER and so the command now breaks. Adding this prefix fixes the issue on my end.

Best,

Ethan